### PR TITLE
Normalize user type field across frontend

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/components/ContactUpgradeAlert.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/ContactUpgradeAlert.tsx
@@ -20,7 +20,7 @@ I would like to upgrade my account to Power User for unlimited document processi
 
 Current Usage:
 - Documents Processed: ${userStats.documents_processed}/${userStats.max_documents_allowed}
-- Account Type: ${userStats.user_type}
+- Account Type: ${userStats.userType}
 
 Please let me know the next steps.
 

--- a/ADPfrontendfor-jsonly-main/src/components/Login.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/Login.tsx
@@ -65,7 +65,7 @@ const Login = () => {
     try {
       if (isSignIn) {
         const data = await apiService.login(username, password);
-        const { access, refresh, username: respUsername, user_type, id } = data;
+        const { access, refresh, username: respUsername, userType, id } = data;
         setPopupMessage(`Login successful! Welcome ${respUsername}`);
 
         dispatch(
@@ -74,7 +74,7 @@ const Login = () => {
             refreshToken: refresh,
             userId: id.toString(),
             username: respUsername,
-            userType: user_type,
+            userType,
           })
         );
         const usageStats = await apiService.getUsageStats();

--- a/ADPfrontendfor-jsonly-main/src/components/UsageBadge.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UsageBadge.tsx
@@ -2,6 +2,7 @@ interface Props {
   current: number;
   max: number | null;
   className?: string;
+  userType?: string;
 }
 
 const UsageBadge = ({ current, max, className = '' }: Props) => (

--- a/ADPfrontendfor-jsonly-main/src/components/UserManagementTable.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UserManagementTable.tsx
@@ -23,7 +23,7 @@ import { useErrorHandler } from '@/hooks/useErrorHandler';
 interface User {
   id: string;
   username: string;
-  user_type: string;
+  userType: string;
   documents_processed: number;
   max_documents_allowed: number;
   last_login: string;
@@ -77,13 +77,13 @@ const UserManagementTable = ({ users, onUserUpdate }: Props) => {
               <TableRow key={user.id}>
                 <TableCell>{user.username}</TableCell>
                 <TableCell>
-                  <UserTypeIndicator userType={user.user_type} />
+                  <UserTypeIndicator userType={user.userType} />
                 </TableCell>
                 <TableCell>
                   <UsageBadge
                     current={user.documents_processed}
                     max={user.max_documents_allowed}
-                    userType={user.user_type}
+                    userType={user.userType}
                   />
                 </TableCell>
                 <TableCell>{user.last_login}</TableCell>

--- a/ADPfrontendfor-jsonly-main/src/services/apiClient.ts
+++ b/ADPfrontendfor-jsonly-main/src/services/apiClient.ts
@@ -3,6 +3,22 @@ import { store } from '@/store';
 
 const getAccessToken = () => store.getState().auth.accessToken;
 
+// Recursively replace `user_type` keys with `userType`
+const normalizeUserType = (data: unknown): unknown => {
+  if (Array.isArray(data)) {
+    return data.map(normalizeUserType);
+  }
+  if (data && typeof data === 'object') {
+    return Object.fromEntries(
+      Object.entries(data as Record<string, unknown>).map(([key, value]) => [
+        key === 'user_type' ? 'userType' : key,
+        normalizeUserType(value),
+      ])
+    );
+  }
+  return data;
+};
+
 export const apiClient = async (
   endpoint: string,
   options: RequestInit = {},
@@ -50,6 +66,7 @@ export const apiClient = async (
     return null;
   }
 
-  return response.json();
+  const data = await response.json();
+  return normalizeUserType(data);
 };
 


### PR DESCRIPTION
## Summary
- Convert snake_case `user_type` fields to camelCase at API layer
- Update login, admin management, and alerts to consume `userType`
- Allow usage badge to accept optional `userType` prop

## Testing
- `npm run lint`
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_6894ea03c930832e9785297b43ea20d7