### PR TITLE
Normalize backend responses to camelCase

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/components/AdminAnalytics.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/AdminAnalytics.tsx
@@ -3,15 +3,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const AdminAnalytics = ({ userReport }) => {
   const userTypeData = [
-    { name: 'Default Users', value: userReport?.statistics?.users_by_type?.default || 0 },
-    { name: 'Power Users', value: userReport?.statistics?.users_by_type?.power || 0 },
-    { name: 'Admin Users', value: userReport?.statistics?.users_by_type?.admin || 0 }
+    { name: 'Default Users', value: userReport?.statistics?.usersByType?.default || 0 },
+    { name: 'Power Users', value: userReport?.statistics?.usersByType?.power || 0 },
+    { name: 'Admin Users', value: userReport?.statistics?.usersByType?.admin || 0 }
   ];
 
   const usageData = [
-    { name: 'Active Users', value: userReport?.statistics?.active_users || 0 },
-    { name: 'At Limit', value: userReport?.statistics?.users_at_limit || 0 },
-    { name: 'Near Limit', value: userReport?.statistics?.users_near_limit || 0 }
+    { name: 'Active Users', value: userReport?.statistics?.activeUsers || 0 },
+    { name: 'At Limit', value: userReport?.statistics?.usersAtLimit || 0 },
+    { name: 'Near Limit', value: userReport?.statistics?.usersNearLimit || 0 }
   ];
 
   return (

--- a/ADPfrontendfor-jsonly-main/src/components/ContactUpgradeAlert.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/ContactUpgradeAlert.tsx
@@ -19,8 +19,8 @@ Hello,
 I would like to upgrade my account to Power User for unlimited document processing.
 
 Current Usage:
-- Documents Processed: ${userStats.documents_processed}/${userStats.max_documents_allowed}
-- Account Type: ${userStats.user_type}
+- Documents Processed: ${userStats.documentsProcessed}/${userStats.maxDocumentsAllowed}
+- Account Type: ${userStats.userType}
 
 Please let me know the next steps.
 
@@ -36,7 +36,7 @@ Thank you!
       <AlertCircle className="h-4 w-4" />
       <AlertTitle>Document Limit Reached</AlertTitle>
       <AlertDescription>
-        You've reached your limit of {userStats.max_documents_allowed} documents.
+        You've reached your limit of {userStats.maxDocumentsAllowed} documents.
         <div className="mt-3 flex gap-2">
           <Button
             size="sm"

--- a/ADPfrontendfor-jsonly-main/src/components/DashboardCards.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/DashboardCards.tsx
@@ -19,7 +19,7 @@ interface DashboardStat {
 }
 
 interface DocumentInfo {
-  entry_date: string;
+  entryDate: string;
 }
 
 const DashboardCards = () => {
@@ -40,7 +40,7 @@ const DashboardCards = () => {
         if (data.documents) {
           const totalDocuments = data.documents.length;
           const today = new Date().toISOString().split('T')[0];
-          const uploadedToday = data.documents.filter((doc: DocumentInfo) => doc.entry_date === today).length;
+          const uploadedToday = data.documents.filter((doc: DocumentInfo) => doc.entryDate === today).length;
 
           const downloaded = 0;
           const pending = 0;
@@ -75,9 +75,9 @@ const DashboardCards = () => {
           if (usageStats && userType === 'default') {
             newStats.push({
               title: 'Document Usage',
-              value: `${usageStats.documents_processed}/${usageStats.max_documents_allowed}`,
+              value: `${usageStats.documentsProcessed}/${usageStats.maxDocumentsAllowed}`,
               icon: <AlertCircle className="h-5 w-5 text-amber-500" />,
-              description: `${usageStats.max_documents_allowed - usageStats.documents_processed} remaining`,
+              description: `${usageStats.maxDocumentsAllowed - usageStats.documentsProcessed} remaining`,
             });
           }
 
@@ -116,7 +116,7 @@ const DashboardCards = () => {
       ))}
 
       {userType === 'default' &&
-        usageStats?.documents_processed >= usageStats?.max_documents_allowed && (
+        usageStats?.documentsProcessed >= usageStats?.maxDocumentsAllowed && (
           <ContactUpgradeAlert userStats={usageStats} />
         )}
     </div>

--- a/ADPfrontendfor-jsonly-main/src/components/DocumentList.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/DocumentList.tsx
@@ -11,9 +11,9 @@ import { handleError } from '@/lib/utils';
 interface Doc {
   id: string;
   filename: string;
-  entry_date: string;
-  pages_processed: number;
-  is_full_document: boolean;
+  entryDate: string;
+  pagesProcessed: number;
+  isFullDocument: boolean;
 }
 
 interface Props {
@@ -51,15 +51,15 @@ const DocumentList = ({ documents }: Props) => {
             <div>
               <h3 className="font-medium">{doc.filename}</h3>
               <div className="flex gap-4 text-sm text-gray-600 mt-1">
-                <span>📅 {doc.entry_date}</span>
-                <span>📄 {doc.pages_processed || 'Unknown'} pages processed</span>
-                {!doc.is_full_document && (
+                <span>📅 {doc.entryDate}</span>
+                <span>📄 {doc.pagesProcessed || 'Unknown'} pages processed</span>
+                {!doc.isFullDocument && (
                   <span className="text-orange-600">⚠️ Partial document</span>
                 )}
               </div>
             </div>
             <div className="flex gap-2">
-              {!doc.is_full_document && (userType === 'power' || userType === 'admin') && (
+              {!doc.isFullDocument && (userType === 'power' || userType === 'admin') && (
                 <Button
                   size="sm"
                   variant="outline"

--- a/ADPfrontendfor-jsonly-main/src/components/DocumentViewer.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/DocumentViewer.tsx
@@ -14,12 +14,12 @@ import config from '@/config';
 interface DocumentData {
   filepath: string;
   filename?: string;
-  original_filename?: string;
-  json_data?: Record<string, unknown> | null;
-  pages_processed?: number;
-  is_full_document?: boolean;
-  input_token?: number;
-  output_token?: number;
+  originalFilename?: string;
+  jsonData?: Record<string, unknown> | null;
+  pagesProcessed?: number;
+  isFullDocument?: boolean;
+  inputToken?: number;
+  outputToken?: number;
   status?: string;
 }
 
@@ -34,12 +34,12 @@ const DocumentProcessingInfo: React.FC<DocumentProcessingInfoProps> = ({ documen
       <div className="grid grid-cols-2 gap-4 text-sm">
         <div>
           <span className="text-gray-600">Pages Processed:</span>
-          <span className="ml-2 font-medium">{documentData.pages_processed || 'Unknown'}</span>
+          <span className="ml-2 font-medium">{documentData.pagesProcessed || 'Unknown'}</span>
         </div>
         <div>
           <span className="text-gray-600">Processing Type:</span>
           <span className="ml-2">
-            {documentData.is_full_document ? (
+            {documentData.isFullDocument ? (
               <span className="text-green-600 font-medium">Full Document</span>
             ) : (
               <span className="text-orange-600 font-medium">Partial (3 pages)</span>
@@ -48,11 +48,11 @@ const DocumentProcessingInfo: React.FC<DocumentProcessingInfoProps> = ({ documen
         </div>
         <div>
           <span className="text-gray-600">Input Tokens:</span>
-          <span className="ml-2 font-medium">{documentData.input_token || 'N/A'}</span>
+          <span className="ml-2 font-medium">{documentData.inputToken || 'N/A'}</span>
         </div>
         <div>
           <span className="text-gray-600">Output Tokens:</span>
-          <span className="ml-2 font-medium">{documentData.output_token || 'N/A'}</span>
+          <span className="ml-2 font-medium">{documentData.outputToken || 'N/A'}</span>
         </div>
       </div>
     </div>
@@ -121,8 +121,8 @@ const DocumentViewer: React.FC = () => {
     if (documentKey) {
       try {
         const storedData = JSON.parse(localStorage.getItem(documentKey));
-        if (storedData?.document_id) {
-          setDocumentId(String(storedData.document_id));
+        if (storedData?.documentId) {
+          setDocumentId(String(storedData.documentId));
         }
       } catch (e) {
         handleError(e as { status?: number; message?: string }, 'Error parsing localStorage data');
@@ -191,13 +191,13 @@ const DocumentViewer: React.FC = () => {
   const getDisplayFilename = () => {
     return (
       documentData?.filename ||
-      documentData?.original_filename ||
+      documentData?.originalFilename ||
       documentData?.filepath?.split('/').pop()
     );
   };
 
   const handleDownloadJSON = () => {
-  const json = documentData?.json_data;
+  const json = documentData?.jsonData;
   if (!json) return;
 
   const blob = new Blob([JSON.stringify(json, null, 2)], { type: 'application/json' });
@@ -260,14 +260,14 @@ const DocumentViewer: React.FC = () => {
               Back
             </button>
             <div className="flex items-center space-x-4">
-              {documentData?.input_token && (
+              {documentData?.inputToken && (
                 <span className="text-sm text-gray-600">
-                  Input Tokens: <strong>{documentData.input_token}</strong>
+                  Input Tokens: <strong>{documentData.inputToken}</strong>
                 </span>
               )}
-              {documentData?.output_token && (
+              {documentData?.outputToken && (
                 <span className="text-sm text-gray-600">
-                  Output Tokens: <strong>{documentData.output_token}</strong>
+                  Output Tokens: <strong>{documentData.outputToken}</strong>
                 </span>
               )}
               {documentData?.status && (
@@ -317,7 +317,7 @@ const DocumentViewer: React.FC = () => {
     <h2 className="text-lg font-semibold text-gray-800 m-0 leading-tight">Extracted Data</h2>
   </div>
               <div className="flex items-center gap-2 relative">
-                {documentData && !documentData.is_full_document && (userType === 'power' || userType === 'admin') && (
+                {documentData && !documentData.isFullDocument && (userType === 'power' || userType === 'admin') && (
                   <button
                     onClick={handleProcessFullDocument}
                     className="px-3 py-1 text-sm bg-orange-600 text-white rounded hover:bg-orange-700"
@@ -350,9 +350,9 @@ const DocumentViewer: React.FC = () => {
             </div>
 
             <div className="flex-1 overflow-auto max-h-[500px] min-h-[300px] rounded border p-3 bg-gray-50">
-              {documentData?.json_data ? (
+              {documentData?.jsonData ? (
                 <pre className="text-sm text-gray-800 whitespace-pre-wrap break-words">
-                  {JSON.stringify(documentData.json_data, null, 2)}
+                  {JSON.stringify(documentData.jsonData, null, 2)}
                 </pre>
               ) : (
                 <div className="text-gray-500 text-center">

--- a/ADPfrontendfor-jsonly-main/src/components/FileUploader.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/FileUploader.tsx
@@ -20,7 +20,7 @@ const FileUploader = ({ onFileUpload }: FileUploaderProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [prompt, setPrompt] = useState('');
-  const [doc_type, setDocType] = useState('docextraction'); // ✅ State with correct name
+  const [docType, setDocType] = useState('docextraction');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -70,40 +70,40 @@ const FileUploader = ({ onFileUpload }: FileUploaderProps) => {
       const response = prompt.trim()
         ? await apiService.uploadDocument(
             file,
-            doc_type,
+            docType,
             processFullDocument,
             prompt
           )
         : await apiService.uploadDocument(
             file,
-            doc_type,
+            docType,
             processFullDocument
           );
       onFileUpload(file);
 
-      if (response && response.document_id) {
-        const documentId = String(response.document_id);
-        if (response.progress_messages) {
-          setProgressMessages(response.progress_messages);
+      if (response && response.documentId) {
+        const documentId = String(response.documentId);
+        if (response.progressMessages) {
+          setProgressMessages(response.progressMessages);
         }
         dispatch(
           setDocumentData({
             documentId,
             documentData: {
               ...response,
-              pages_processed: response.pages_processed,
-              is_full_document: response.is_full_document,
-              progress_messages: response.progress_messages,
+              pagesProcessed: response.pagesProcessed,
+              isFullDocument: response.isFullDocument,
+              progressMessages: response.progressMessages,
             },
           })
         );
 
-        if (response.usage_info) {
-          dispatch(updateUsageStats(response.usage_info));
+        if (response.usageInfo) {
+          dispatch(updateUsageStats(response.usageInfo));
         }
 
         toast.success(
-          `Document processed successfully! ${response.pages_processed} pages processed.`
+          `Document processed successfully! ${response.pagesProcessed} pages processed.`
         );
         navigate(`/document/${documentId}`);
       } else {
@@ -177,7 +177,7 @@ const FileUploader = ({ onFileUpload }: FileUploaderProps) => {
             <input
               type="radio"
               value="docextraction"
-              checked={doc_type === 'docextraction'}
+              checked={docType === 'docextraction'}
               onChange={handleDocTypeChange}
             />
             Document Extraction
@@ -186,7 +186,7 @@ const FileUploader = ({ onFileUpload }: FileUploaderProps) => {
             <input
               type="radio"
               value="Bill Reimbursment"
-              checked={doc_type === 'Bill Reimbursment'}
+              checked={docType === 'Bill Reimbursment'}
               onChange={handleDocTypeChange}
             />
             Bill Reimbursment

--- a/ADPfrontendfor-jsonly-main/src/components/FullDocumentProcessor.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/FullDocumentProcessor.tsx
@@ -18,7 +18,7 @@ const FullDocumentProcessor = ({ documentId, onSuccess }: Props) => {
     setIsProcessing(true);
     try {
       const result = await apiService.processFullDocument(documentId);
-      setProgress(result.progress_messages);
+      setProgress(result.progressMessages);
       onSuccess(result);
       toast.success('Full document processed successfully!');
     } catch (error) {

--- a/ADPfrontendfor-jsonly-main/src/components/Login.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/Login.tsx
@@ -65,7 +65,7 @@ const Login = () => {
     try {
       if (isSignIn) {
         const data = await apiService.login(username, password);
-        const { access, refresh, username: respUsername, user_type, id } = data;
+        const { access, refresh, username: respUsername, userType, id } = data;
         setPopupMessage(`Login successful! Welcome ${respUsername}`);
 
         dispatch(
@@ -74,7 +74,7 @@ const Login = () => {
             refreshToken: refresh,
             userId: id.toString(),
             username: respUsername,
-            userType: user_type,
+            userType,
           })
         );
         const usageStats = await apiService.getUsageStats();

--- a/ADPfrontendfor-jsonly-main/src/components/UsageBadge.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UsageBadge.tsx
@@ -2,6 +2,7 @@ interface Props {
   current: number;
   max: number | null;
   className?: string;
+  userType?: string;
 }
 
 const UsageBadge = ({ current, max, className = '' }: Props) => (

--- a/ADPfrontendfor-jsonly-main/src/components/UsageStatistics.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UsageStatistics.tsx
@@ -7,8 +7,8 @@ import UserTypeIndicator from './UserTypeIndicator';
 import { useUsageStats } from '@/hooks/useUsageStats';
 
 interface UsageStats {
-  documents_processed: number;
-  max_documents_allowed: number;
+  documentsProcessed: number;
+  maxDocumentsAllowed: number;
   warnings?: string[];
 }
 
@@ -27,7 +27,7 @@ const UsageStatistics = () => {
       </CardHeader>
       <CardContent>
         <div className="mb-2 text-sm">
-          {usageStats?.documents_processed}/{usageStats?.max_documents_allowed} documents processed
+          {usageStats?.documentsProcessed}/{usageStats?.maxDocumentsAllowed} documents processed
         </div>
         {usageStats?.warnings?.map((warning: string) => (
           <Alert key={warning} className="mt-2 border-yellow-200 bg-yellow-50">

--- a/ADPfrontendfor-jsonly-main/src/components/UserDashboard/UserDashboard.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UserDashboard/UserDashboard.tsx
@@ -14,8 +14,8 @@ const UserDashboard = () => {
   const [documents, setDocuments] = useState([]);
   const [filteredDocuments, setFilteredDocuments] = useState([]);
   const [count, setCount] = useState(0);
-  const [total_input_tokens, setTotal_input_tokens] = useState(0);
-  const [total_output_tokens, setTotal_output_tokens] = useState(0);
+  const [totalInputTokens, setTotalInputTokens] = useState(0);
+  const [totalOutputTokens, setTotalOutputTokens] = useState(0);
   const [searchDate, setSearchDate] = useState('');
   const [searchName, setSearchName] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
@@ -35,10 +35,10 @@ const UserDashboard = () => {
 
     apiService.listDocuments()
       .then((data) => {
-        const { count, documents, total_input_tokens, total_output_tokens } = data;
+        const { count, documents, totalInputTokens, totalOutputTokens } = data;
         setCount(count);
-        setTotal_input_tokens(total_input_tokens);
-        setTotal_output_tokens(total_output_tokens);
+        setTotalInputTokens(totalInputTokens);
+        setTotalOutputTokens(totalOutputTokens);
         const docsWithStringId = documents.map((doc) => ({ ...doc, id: String(doc.id) }));
         setDocuments(docsWithStringId);
         setFilteredDocuments(docsWithStringId);
@@ -140,13 +140,13 @@ const UserDashboard = () => {
         <Card>
           <CardContent className="p-4">
             <p className="text-sm text-muted-foreground">Total used input tokens</p>
-            <h2 className="text-2xl font-bold">{total_input_tokens}</h2>
+            <h2 className="text-2xl font-bold">{totalInputTokens}</h2>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4">
             <p className="text-sm text-muted-foreground">Total used output tokens</p>
-            <h2 className="text-2xl font-bold">{total_output_tokens}</h2>
+            <h2 className="text-2xl font-bold">{totalOutputTokens}</h2>
           </CardContent>
         </Card>
         <Card>

--- a/ADPfrontendfor-jsonly-main/src/components/UserManagementTable.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UserManagementTable.tsx
@@ -23,10 +23,10 @@ import { useErrorHandler } from '@/hooks/useErrorHandler';
 interface User {
   id: string;
   username: string;
-  user_type: string;
-  documents_processed: number;
-  max_documents_allowed: number;
-  last_login: string;
+  userType: string;
+  documentsProcessed: number;
+  maxDocumentsAllowed: number;
+  lastLogin: string;
 }
 
 interface Props {
@@ -77,16 +77,16 @@ const UserManagementTable = ({ users, onUserUpdate }: Props) => {
               <TableRow key={user.id}>
                 <TableCell>{user.username}</TableCell>
                 <TableCell>
-                  <UserTypeIndicator userType={user.user_type} />
+                  <UserTypeIndicator userType={user.userType} />
                 </TableCell>
                 <TableCell>
                   <UsageBadge
-                    current={user.documents_processed}
-                    max={user.max_documents_allowed}
-                    userType={user.user_type}
+                    current={user.documentsProcessed}
+                    max={user.maxDocumentsAllowed}
+                    userType={user.userType}
                   />
                 </TableCell>
-                <TableCell>{user.last_login}</TableCell>
+                <TableCell>{user.lastLogin}</TableCell>
                 <TableCell>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/ADPfrontendfor-jsonly-main/src/pages/AdminDashboard.tsx
+++ b/ADPfrontendfor-jsonly-main/src/pages/AdminDashboard.tsx
@@ -32,19 +32,19 @@ const AdminDashboard = () => {
 
       {/* User Statistics Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <StatCard 
-          title="Total Users" 
-          value={userReport?.statistics?.total_users} 
-          breakdown={userReport?.statistics?.users_by_type}
+        <StatCard
+          title="Total Users"
+          value={userReport?.statistics?.totalUsers}
+          breakdown={userReport?.statistics?.usersByType}
         />
-        <StatCard 
-          title="Users at Limit" 
-          value={userReport?.statistics?.users_at_limit}
+        <StatCard
+          title="Users at Limit"
+          value={userReport?.statistics?.usersAtLimit}
           color="red"
         />
-        <StatCard 
-          title="Active This Month" 
-          value={userReport?.statistics?.active_users}
+        <StatCard
+          title="Active This Month"
+          value={userReport?.statistics?.activeUsers}
           color="green"
         />
       </div>

--- a/ADPfrontendfor-jsonly-main/src/services/apiClient.ts
+++ b/ADPfrontendfor-jsonly-main/src/services/apiClient.ts
@@ -3,6 +3,25 @@ import { store } from '@/store';
 
 const getAccessToken = () => store.getState().auth.accessToken;
 
+// Convert snake_case keys to camelCase recursively
+const toCamel = (str: string) =>
+  str.replace(/[_-](\w)/g, (_, c: string) => c.toUpperCase());
+
+const normalizeKeys = (data: unknown): unknown => {
+  if (Array.isArray(data)) {
+    return data.map(normalizeKeys);
+  }
+  if (data && typeof data === 'object') {
+    return Object.fromEntries(
+      Object.entries(data as Record<string, unknown>).map(([key, value]) => [
+        toCamel(key),
+        normalizeKeys(value),
+      ])
+    );
+  }
+  return data;
+};
+
 export const apiClient = async (
   endpoint: string,
   options: RequestInit = {},
@@ -50,6 +69,7 @@ export const apiClient = async (
     return null;
   }
 
-  return response.json();
+  const data = await response.json();
+  return normalizeKeys(data);
 };
 

--- a/ADPfrontendfor-jsonly-main/src/store/authSlice.ts
+++ b/ADPfrontendfor-jsonly-main/src/store/authSlice.ts
@@ -109,26 +109,26 @@ const authSlice = createSlice({
     updateUsageStats: (
       state,
       action: PayloadAction<{
-        documents_processed?: number;
-        max_documents_allowed?: number | null;
-        can_process_more?: boolean;
+        documentsProcessed?: number;
+        maxDocumentsAllowed?: number | null;
+        canProcessMore?: boolean;
         warnings?: string[];
       }>
     ) => {
       const {
-        documents_processed,
-        max_documents_allowed,
-        can_process_more,
+        documentsProcessed,
+        maxDocumentsAllowed,
+        canProcessMore,
         warnings,
       } = action.payload;
-      if (typeof documents_processed === 'number') {
-        state.documentsProcessed = documents_processed;
+      if (typeof documentsProcessed === 'number') {
+        state.documentsProcessed = documentsProcessed;
       }
-      if (max_documents_allowed !== undefined) {
-        state.maxDocumentsAllowed = max_documents_allowed;
+      if (maxDocumentsAllowed !== undefined) {
+        state.maxDocumentsAllowed = maxDocumentsAllowed;
       }
-      if (typeof can_process_more === 'boolean') {
-        state.canProcessMore = can_process_more;
+      if (typeof canProcessMore === 'boolean') {
+        state.canProcessMore = canProcessMore;
       }
       if (warnings) {
         state.usageWarnings = warnings;

--- a/experiencecentrejsononly-main/ImageExtraction/settings.py
+++ b/experiencecentrejsononly-main/ImageExtraction/settings.py
@@ -106,16 +106,24 @@ WSGI_APPLICATION = "ImageExtraction.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("DB_NAME"),
-        "USER": os.getenv("DB_USER"),
-        "PASSWORD": os.getenv("DB_PASSWORD"),
-        "HOST": os.getenv("DB_HOST"),
-        "PORT": os.getenv("DB_PORT"),
+if os.getenv("DB_NAME"):
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.getenv("DB_NAME"),
+            "USER": os.getenv("DB_USER"),
+            "PASSWORD": os.getenv("DB_PASSWORD"),
+            "HOST": os.getenv("DB_HOST"),
+            "PORT": os.getenv("DB_PORT"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
 
 
 


### PR DESCRIPTION
## Summary
- Convert all API responses from snake_case to camelCase via recursive normalizer
- Update usage stats, admin reports, and document components to consume camelCase data
- Fallback to SQLite when database env vars are missing so Django tests can run

## Testing
- `npm run lint`
- `python manage.py test` *(fails: Error initializing Vertex AI: stat: path should be string, bytes, os.PathLike or integer, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_6894ea03c930832e9785297b43ea20d7