### PR TITLE
Standardize authentication userType naming

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/components/Login.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/Login.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { setAuthData, updateUsageStats } from '../store/authSlice';
 import { useNavigate } from 'react-router-dom';
 import useBranding from '@/hooks/useBranding';
-import { apiService } from '@/services/apiService';
+import { apiService, LoginResponse } from '@/services/apiService';
 import { useErrorHandler } from '@/hooks/useErrorHandler';
 
 const Login = () => {
@@ -64,8 +64,17 @@ const Login = () => {
 
     try {
       if (isSignIn) {
-        const data = await apiService.login(username, password);
-        const { access, refresh, username: respUsername, userType, id } = data;
+        const data = (await apiService.login(
+          username,
+          password
+        )) as LoginResponse;
+        const {
+          access,
+          refresh,
+          username: respUsername,
+          userType,
+          id,
+        } = data;
         setPopupMessage(`Login successful! Welcome ${respUsername}`);
 
         dispatch(

--- a/ADPfrontendfor-jsonly-main/src/services/apiService.ts
+++ b/ADPfrontendfor-jsonly-main/src/services/apiService.ts
@@ -1,11 +1,20 @@
 import { apiClient } from '@/services/apiClient';
 
+export interface LoginResponse {
+  access: string;
+  refresh: string;
+  username: string;
+  userType: 'default' | 'power' | 'admin';
+  id: number;
+  message?: string;
+}
+
 export const apiService = {
-  login: async (username: string, password: string) => {
+  login: async (username: string, password: string): Promise<LoginResponse> => {
     return apiClient('/login/', {
       method: 'POST',
       body: JSON.stringify({ username, password }),
-    });
+    }) as Promise<LoginResponse>;
   },
 
   createUser: async (

--- a/experiencecentrejsononly-main/apps/authentication/views.py
+++ b/experiencecentrejsononly-main/apps/authentication/views.py
@@ -126,7 +126,8 @@ class LoginView(APIView):
                     'access': str(refresh.access_token),
                     'username': username,
                     'id': user.id,
-                    'user_type': user.user_type,
+                    # Use camelCase to match frontend expectations
+                    'userType': user.user_type,
                     'message': 'Login successful'
                 }, status=status.HTTP_200_OK)
             else:


### PR DESCRIPTION
## Summary
- Return `userType` from login endpoint in camelCase
- Type login response and expose `LoginResponse` in API service
- Use typed login response in component to store `userType`

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f43154dc832ea2dec772a0720cdd