### PR TITLE
Send userid in document filter request

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/services/apiService.ts
+++ b/ADPfrontendfor-jsonly-main/src/services/apiService.ts
@@ -56,7 +56,7 @@ export const apiService = {
   filterDocuments: async (userId: string, date: string) => {
     return apiClient('/document-filter/', {
       method: 'POST',
-      body: JSON.stringify({ user_id: userId, date }),
+      body: JSON.stringify({ userid: userId, date }),
     });
   },
   uploadDocument: async (


### PR DESCRIPTION
## Summary
- match backend naming when filtering documents

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f62f06ec832e8775d382e607341c