### PR TITLE
Align admin report with camelCase usage

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/components/AdminAnalytics.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/AdminAnalytics.tsx
@@ -3,15 +3,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const AdminAnalytics = ({ userReport }) => {
   const userTypeData = [
-    { name: 'Default Users', value: userReport?.statistics?.users_by_type?.default || 0 },
-    { name: 'Power Users', value: userReport?.statistics?.users_by_type?.power || 0 },
-    { name: 'Admin Users', value: userReport?.statistics?.users_by_type?.admin || 0 }
+    { name: 'Default Users', value: userReport?.statistics?.usersByType?.default || 0 },
+    { name: 'Power Users', value: userReport?.statistics?.usersByType?.power || 0 },
+    { name: 'Admin Users', value: userReport?.statistics?.usersByType?.admin || 0 }
   ];
 
   const usageData = [
-    { name: 'Active Users', value: userReport?.statistics?.active_users || 0 },
-    { name: 'At Limit', value: userReport?.statistics?.users_at_limit || 0 },
-    { name: 'Near Limit', value: userReport?.statistics?.users_near_limit || 0 }
+    { name: 'Active Users', value: userReport?.statistics?.activeUsers || 0 },
+    { name: 'At Limit', value: userReport?.statistics?.usersAtLimit || 0 },
+    { name: 'Near Limit', value: userReport?.statistics?.usersNearLimit || 0 }
   ];
 
   return (

--- a/ADPfrontendfor-jsonly-main/src/components/ContactUpgradeAlert.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/ContactUpgradeAlert.tsx
@@ -19,7 +19,7 @@ Hello,
 I would like to upgrade my account to Power User for unlimited document processing.
 
 Current Usage:
-- Documents Processed: ${userStats.documents_processed}/${userStats.max_documents_allowed}
+- Documents Processed: ${userStats.documentsProcessed}/${userStats.maxDocumentsAllowed}
 - Account Type: ${userStats.userType}
 
 Please let me know the next steps.
@@ -36,7 +36,7 @@ Thank you!
       <AlertCircle className="h-4 w-4" />
       <AlertTitle>Document Limit Reached</AlertTitle>
       <AlertDescription>
-        You've reached your limit of {userStats.max_documents_allowed} documents.
+        You've reached your limit of {userStats.maxDocumentsAllowed} documents.
         <div className="mt-3 flex gap-2">
           <Button
             size="sm"

--- a/ADPfrontendfor-jsonly-main/src/components/DashboardCards.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/DashboardCards.tsx
@@ -19,7 +19,7 @@ interface DashboardStat {
 }
 
 interface DocumentInfo {
-  entry_date: string;
+  entryDate: string;
 }
 
 const DashboardCards = () => {
@@ -40,7 +40,7 @@ const DashboardCards = () => {
         if (data.documents) {
           const totalDocuments = data.documents.length;
           const today = new Date().toISOString().split('T')[0];
-          const uploadedToday = data.documents.filter((doc: DocumentInfo) => doc.entry_date === today).length;
+          const uploadedToday = data.documents.filter((doc: DocumentInfo) => doc.entryDate === today).length;
 
           const downloaded = 0;
           const pending = 0;
@@ -75,9 +75,9 @@ const DashboardCards = () => {
           if (usageStats && userType === 'default') {
             newStats.push({
               title: 'Document Usage',
-              value: `${usageStats.documents_processed}/${usageStats.max_documents_allowed}`,
+              value: `${usageStats.documentsProcessed}/${usageStats.maxDocumentsAllowed}`,
               icon: <AlertCircle className="h-5 w-5 text-amber-500" />,
-              description: `${usageStats.max_documents_allowed - usageStats.documents_processed} remaining`,
+              description: `${usageStats.maxDocumentsAllowed - usageStats.documentsProcessed} remaining`,
             });
           }
 
@@ -116,7 +116,7 @@ const DashboardCards = () => {
       ))}
 
       {userType === 'default' &&
-        usageStats?.documents_processed >= usageStats?.max_documents_allowed && (
+        usageStats?.documentsProcessed >= usageStats?.maxDocumentsAllowed && (
           <ContactUpgradeAlert userStats={usageStats} />
         )}
     </div>

--- a/ADPfrontendfor-jsonly-main/src/components/DocumentList.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/DocumentList.tsx
@@ -11,9 +11,9 @@ import { handleError } from '@/lib/utils';
 interface Doc {
   id: string;
   filename: string;
-  entry_date: string;
-  pages_processed: number;
-  is_full_document: boolean;
+  entryDate: string;
+  pagesProcessed: number;
+  isFullDocument: boolean;
 }
 
 interface Props {
@@ -51,15 +51,15 @@ const DocumentList = ({ documents }: Props) => {
             <div>
               <h3 className="font-medium">{doc.filename}</h3>
               <div className="flex gap-4 text-sm text-gray-600 mt-1">
-                <span>📅 {doc.entry_date}</span>
-                <span>📄 {doc.pages_processed || 'Unknown'} pages processed</span>
-                {!doc.is_full_document && (
+                <span>📅 {doc.entryDate}</span>
+                <span>📄 {doc.pagesProcessed || 'Unknown'} pages processed</span>
+                {!doc.isFullDocument && (
                   <span className="text-orange-600">⚠️ Partial document</span>
                 )}
               </div>
             </div>
             <div className="flex gap-2">
-              {!doc.is_full_document && (userType === 'power' || userType === 'admin') && (
+              {!doc.isFullDocument && (userType === 'power' || userType === 'admin') && (
                 <Button
                   size="sm"
                   variant="outline"

--- a/ADPfrontendfor-jsonly-main/src/components/DocumentViewer.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/DocumentViewer.tsx
@@ -14,12 +14,12 @@ import config from '@/config';
 interface DocumentData {
   filepath: string;
   filename?: string;
-  original_filename?: string;
-  json_data?: Record<string, unknown> | null;
-  pages_processed?: number;
-  is_full_document?: boolean;
-  input_token?: number;
-  output_token?: number;
+  originalFilename?: string;
+  jsonData?: Record<string, unknown> | null;
+  pagesProcessed?: number;
+  isFullDocument?: boolean;
+  inputToken?: number;
+  outputToken?: number;
   status?: string;
 }
 
@@ -34,12 +34,12 @@ const DocumentProcessingInfo: React.FC<DocumentProcessingInfoProps> = ({ documen
       <div className="grid grid-cols-2 gap-4 text-sm">
         <div>
           <span className="text-gray-600">Pages Processed:</span>
-          <span className="ml-2 font-medium">{documentData.pages_processed || 'Unknown'}</span>
+          <span className="ml-2 font-medium">{documentData.pagesProcessed || 'Unknown'}</span>
         </div>
         <div>
           <span className="text-gray-600">Processing Type:</span>
           <span className="ml-2">
-            {documentData.is_full_document ? (
+            {documentData.isFullDocument ? (
               <span className="text-green-600 font-medium">Full Document</span>
             ) : (
               <span className="text-orange-600 font-medium">Partial (3 pages)</span>
@@ -48,11 +48,11 @@ const DocumentProcessingInfo: React.FC<DocumentProcessingInfoProps> = ({ documen
         </div>
         <div>
           <span className="text-gray-600">Input Tokens:</span>
-          <span className="ml-2 font-medium">{documentData.input_token || 'N/A'}</span>
+          <span className="ml-2 font-medium">{documentData.inputToken || 'N/A'}</span>
         </div>
         <div>
           <span className="text-gray-600">Output Tokens:</span>
-          <span className="ml-2 font-medium">{documentData.output_token || 'N/A'}</span>
+          <span className="ml-2 font-medium">{documentData.outputToken || 'N/A'}</span>
         </div>
       </div>
     </div>
@@ -191,13 +191,13 @@ const DocumentViewer: React.FC = () => {
   const getDisplayFilename = () => {
     return (
       documentData?.filename ||
-      documentData?.original_filename ||
+      documentData?.originalFilename ||
       documentData?.filepath?.split('/').pop()
     );
   };
 
   const handleDownloadJSON = () => {
-  const json = documentData?.json_data;
+  const json = documentData?.jsonData;
   if (!json) return;
 
   const blob = new Blob([JSON.stringify(json, null, 2)], { type: 'application/json' });
@@ -260,14 +260,14 @@ const DocumentViewer: React.FC = () => {
               Back
             </button>
             <div className="flex items-center space-x-4">
-              {documentData?.input_token && (
+              {documentData?.inputToken && (
                 <span className="text-sm text-gray-600">
-                  Input Tokens: <strong>{documentData.input_token}</strong>
+                  Input Tokens: <strong>{documentData.inputToken}</strong>
                 </span>
               )}
-              {documentData?.output_token && (
+              {documentData?.outputToken && (
                 <span className="text-sm text-gray-600">
-                  Output Tokens: <strong>{documentData.output_token}</strong>
+                  Output Tokens: <strong>{documentData.outputToken}</strong>
                 </span>
               )}
               {documentData?.status && (
@@ -317,7 +317,7 @@ const DocumentViewer: React.FC = () => {
     <h2 className="text-lg font-semibold text-gray-800 m-0 leading-tight">Extracted Data</h2>
   </div>
               <div className="flex items-center gap-2 relative">
-                {documentData && !documentData.is_full_document && (userType === 'power' || userType === 'admin') && (
+                {documentData && !documentData.isFullDocument && (userType === 'power' || userType === 'admin') && (
                   <button
                     onClick={handleProcessFullDocument}
                     className="px-3 py-1 text-sm bg-orange-600 text-white rounded hover:bg-orange-700"
@@ -350,9 +350,9 @@ const DocumentViewer: React.FC = () => {
             </div>
 
             <div className="flex-1 overflow-auto max-h-[500px] min-h-[300px] rounded border p-3 bg-gray-50">
-              {documentData?.json_data ? (
+              {documentData?.jsonData ? (
                 <pre className="text-sm text-gray-800 whitespace-pre-wrap break-words">
-                  {JSON.stringify(documentData.json_data, null, 2)}
+                  {JSON.stringify(documentData.jsonData, null, 2)}
                 </pre>
               ) : (
                 <div className="text-gray-500 text-center">
@@ -360,7 +360,7 @@ const DocumentViewer: React.FC = () => {
                   <p>No JSON data available</p>
                 </div>
               )}
-
+            
             </div>
           </div>
         </div>

--- a/ADPfrontendfor-jsonly-main/src/components/FileUploader.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/FileUploader.tsx
@@ -14,39 +14,33 @@ import ProcessingProgress from './ProcessingProgress';
 
 // Normalize different backend response shapes
 type UploadResponse = {
-  document_id?: string;
   documentId?: string;
-  pages_processed?: number;
   pagesProcessed?: number;
-  is_full_document?: boolean;
   isFullDocument?: boolean;
-  progress_messages?: string[];
   progressMessages?: string[];
-  usage_info?: unknown;
   usageInfo?: unknown;
-  can_load_full_document?: boolean;
   canLoadFullDocument?: boolean;
   [key: string]: unknown;
 };
 
 const normalizeUploadResponse = (response: unknown): UploadResponse => {
   const data =
-    (response as { data?: UploadResponse })?.data ||
-    (response as UploadResponse) ||
+    (response as { data?: Record<string, unknown> })?.data ||
+    (response as Record<string, unknown>) ||
     {};
   return {
     ...data,
-    document_id: (data.document_id ?? data.documentId) as string | undefined,
-    pages_processed: (data.pages_processed ?? data.pagesProcessed) as
+    documentId: (data.document_id ?? data.documentId) as string | undefined,
+    pagesProcessed: (data.pages_processed ?? data.pagesProcessed) as
       | number
       | undefined,
-    is_full_document: (data.is_full_document ?? data.isFullDocument) as
+    isFullDocument: (data.is_full_document ?? data.isFullDocument) as
       | boolean
       | undefined,
-    progress_messages: (data.progress_messages ?? data.progressMessages ?? []) as
+    progressMessages: (data.progress_messages ?? data.progressMessages ?? []) as
       string[],
-    usage_info: data.usage_info ?? data.usageInfo,
-    can_load_full_document: (data.can_load_full_document ??
+    usageInfo: data.usage_info ?? data.usageInfo,
+    canLoadFullDocument: (data.can_load_full_document ??
       data.canLoadFullDocument) as boolean | undefined,
   };
 };
@@ -122,29 +116,29 @@ const FileUploader = ({ onFileUpload }: FileUploaderProps) => {
 
       const response = normalizeUploadResponse(rawResponse);
 
-      if (response && response.document_id) {
-        const documentId = String(response.document_id);
-        if (response.progress_messages) {
-          setProgressMessages(response.progress_messages);
+      if (response && response.documentId) {
+        const documentId = String(response.documentId);
+        if (response.progressMessages) {
+          setProgressMessages(response.progressMessages);
         }
         dispatch(
           setDocumentData({
             documentId,
             documentData: {
               ...response,
-              pages_processed: response.pages_processed,
-              is_full_document: response.is_full_document,
-              progress_messages: response.progress_messages,
+              pagesProcessed: response.pagesProcessed,
+              isFullDocument: response.isFullDocument,
+              progressMessages: response.progressMessages,
             },
           })
         );
 
-        if (response.usage_info) {
-          dispatch(updateUsageStats(response.usage_info));
+        if (response.usageInfo) {
+          dispatch(updateUsageStats(response.usageInfo));
         }
 
         toast.success(
-          `Document processed successfully! ${response.pages_processed} pages processed.`
+          `Document processed successfully! ${response.pagesProcessed} pages processed.`
         );
         navigate(`/document/${documentId}`);
       } else {

--- a/ADPfrontendfor-jsonly-main/src/components/UsageStatistics.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UsageStatistics.tsx
@@ -7,8 +7,8 @@ import UserTypeIndicator from './UserTypeIndicator';
 import { useUsageStats } from '@/hooks/useUsageStats';
 
 interface UsageStats {
-  documents_processed: number;
-  max_documents_allowed: number;
+  documentsProcessed: number;
+  maxDocumentsAllowed: number;
   warnings?: string[];
 }
 
@@ -27,7 +27,7 @@ const UsageStatistics = () => {
       </CardHeader>
       <CardContent>
         <div className="mb-2 text-sm">
-          {usageStats?.documents_processed}/{usageStats?.max_documents_allowed} documents processed
+          {usageStats?.documentsProcessed}/{usageStats?.maxDocumentsAllowed} documents processed
         </div>
         {usageStats?.warnings?.map((warning: string) => (
           <Alert key={warning} className="mt-2 border-yellow-200 bg-yellow-50">

--- a/ADPfrontendfor-jsonly-main/src/components/UserManagementTable.tsx
+++ b/ADPfrontendfor-jsonly-main/src/components/UserManagementTable.tsx
@@ -24,9 +24,9 @@ interface User {
   id: string;
   username: string;
   userType: string;
-  documents_processed: number;
-  max_documents_allowed: number;
-  last_login: string;
+  documentsProcessed: number;
+  maxDocumentsAllowed: number;
+  lastDocumentProcessed: string;
 }
 
 interface Props {
@@ -81,12 +81,12 @@ const UserManagementTable = ({ users, onUserUpdate }: Props) => {
                 </TableCell>
                 <TableCell>
                   <UsageBadge
-                    current={user.documents_processed}
-                    max={user.max_documents_allowed}
+                    current={user.documentsProcessed}
+                    max={user.maxDocumentsAllowed}
                     userType={user.userType}
                   />
                 </TableCell>
-                <TableCell>{user.last_login}</TableCell>
+                <TableCell>{user.lastDocumentProcessed}</TableCell>
                 <TableCell>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/ADPfrontendfor-jsonly-main/src/pages/AdminDashboard.tsx
+++ b/ADPfrontendfor-jsonly-main/src/pages/AdminDashboard.tsx
@@ -32,19 +32,19 @@ const AdminDashboard = () => {
 
       {/* User Statistics Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <StatCard 
-          title="Total Users" 
-          value={userReport?.statistics?.total_users} 
-          breakdown={userReport?.statistics?.users_by_type}
+        <StatCard
+          title="Total Users"
+          value={userReport?.statistics?.totalUsers}
+          breakdown={userReport?.statistics?.usersByType}
         />
-        <StatCard 
-          title="Users at Limit" 
-          value={userReport?.statistics?.users_at_limit}
+        <StatCard
+          title="Users at Limit"
+          value={userReport?.statistics?.usersAtLimit}
           color="red"
         />
-        <StatCard 
-          title="Active This Month" 
-          value={userReport?.statistics?.active_users}
+        <StatCard
+          title="Active This Month"
+          value={userReport?.statistics?.activeUsers}
           color="green"
         />
       </div>

--- a/ADPfrontendfor-jsonly-main/src/services/apiClient.ts
+++ b/ADPfrontendfor-jsonly-main/src/services/apiClient.ts
@@ -3,16 +3,19 @@ import { store } from '@/store';
 
 const getAccessToken = () => store.getState().auth.accessToken;
 
-// Recursively replace `user_type` keys with `userType`
-const normalizeUserType = (data: unknown): unknown => {
+// Convert snake_case keys to camelCase recursively
+const toCamel = (str: string) =>
+  str.replace(/[_-](\w)/g, (_, c) => (c ? c.toUpperCase() : ''));
+
+const camelizeKeys = (data: unknown): unknown => {
   if (Array.isArray(data)) {
-    return data.map(normalizeUserType);
+    return data.map(camelizeKeys);
   }
   if (data && typeof data === 'object') {
     return Object.fromEntries(
       Object.entries(data as Record<string, unknown>).map(([key, value]) => [
-        key === 'user_type' ? 'userType' : key,
-        normalizeUserType(value),
+        toCamel(key),
+        camelizeKeys(value),
       ])
     );
   }
@@ -67,6 +70,6 @@ export const apiClient = async (
   }
 
   const data = await response.json();
-  return normalizeUserType(data);
+  return camelizeKeys(data);
 };
 

--- a/ADPfrontendfor-jsonly-main/src/store/authSlice.ts
+++ b/ADPfrontendfor-jsonly-main/src/store/authSlice.ts
@@ -109,26 +109,26 @@ const authSlice = createSlice({
     updateUsageStats: (
       state,
       action: PayloadAction<{
-        documents_processed?: number;
-        max_documents_allowed?: number | null;
-        can_process_more?: boolean;
+        documentsProcessed?: number;
+        maxDocumentsAllowed?: number | null;
+        canProcessMore?: boolean;
         warnings?: string[];
       }>
     ) => {
       const {
-        documents_processed,
-        max_documents_allowed,
-        can_process_more,
+        documentsProcessed,
+        maxDocumentsAllowed,
+        canProcessMore,
         warnings,
       } = action.payload;
-      if (typeof documents_processed === 'number') {
-        state.documentsProcessed = documents_processed;
+      if (typeof documentsProcessed === 'number') {
+        state.documentsProcessed = documentsProcessed;
       }
-      if (max_documents_allowed !== undefined) {
-        state.maxDocumentsAllowed = max_documents_allowed;
+      if (maxDocumentsAllowed !== undefined) {
+        state.maxDocumentsAllowed = maxDocumentsAllowed;
       }
-      if (typeof can_process_more === 'boolean') {
-        state.canProcessMore = can_process_more;
+      if (typeof canProcessMore === 'boolean') {
+        state.canProcessMore = canProcessMore;
       }
       if (warnings) {
         state.usageWarnings = warnings;

--- a/experiencecentrejsononly-main/apps/image_app/admin_views.py
+++ b/experiencecentrejsononly-main/apps/image_app/admin_views.py
@@ -106,22 +106,22 @@ class AdminUserReportView(APIView):
             # Recent registrations (last 30 days)
             recent_registrations = len([u for u in user_reports if u['days_registered'] <= 30])
             
-            summary = {
+            statistics = {
                 "total_users": total_users,
                 "active_users": active_users,
                 "inactive_users": total_users - active_users,
                 "users_at_limit": users_at_limit,
-                "users_approaching_limit": users_approaching_limit,
+                "users_near_limit": users_approaching_limit,
                 "recent_registrations_30d": recent_registrations,
-                "user_type_breakdown": user_type_stats,
+                "users_by_type": user_type_stats,
                 "total_documents_processed": sum(u['total_documents_in_db'] for u in user_reports),
                 "total_pages_processed": sum(u['total_pages_processed'] for u in user_reports),
                 "total_tokens_consumed": sum(u['total_tokens'] for u in user_reports)
             }
-            
+
             return Response({
                 "status": "success",
-                "summary": summary,
+                "statistics": statistics,
                 "users": user_reports,
                 "generated_at": timezone.now().strftime("%Y-%m-%d %H:%M:%S")
             }, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- Return `statistics` from admin user report and include consistent fields
- Convert all API responses to camelCase and update frontend usage stats
- Revise admin dashboard and related components to consume camelCase data

## Testing
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f7693444832ea15f6bb5e80458fb