### PR TITLE
Implement automatic token refresh

### DIFF
--- a/experiencecentrejsononly-main/README.md
+++ b/experiencecentrejsononly-main/README.md
@@ -158,6 +158,7 @@ The API will be available at `http://127.0.0.1:8000/` by default.
 ### Authentication
 - `POST /IDA/create_user/` – Register a new user (defaults to 'default' user type)
 - `POST /IDA/login/` – Obtain JWT tokens
+- `POST /IDA/token/refresh/` – Refresh access token using a refresh token
 - `GET /profile/` – Fetch details of the authenticated user
 - `POST /IDA/password-reset/` – Send a password reset email
 - `POST /IDA/password-reset-confirm/` – Reset password using provided token

--- a/experiencecentrejsononly-main/apps/authentication/urls.py
+++ b/experiencecentrejsononly-main/apps/authentication/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from rest_framework_simplejwt.views import TokenRefreshView
 from .views import (
     LoginView,
     CreateUserAPIView,
@@ -16,4 +17,5 @@ urlpatterns = [
     path('users/', UserListView.as_view(), name='user-list'),
     path('IDA/password-reset/', PasswordResetRequestView.as_view(), name='password-reset'),
     path('IDA/password-reset-confirm/', PasswordResetConfirmView.as_view(), name='password-reset-confirm'),
+    path('IDA/token/refresh/', TokenRefreshView.as_view(), name='token-refresh'),
 ]


### PR DESCRIPTION
## Summary
- add token refresh endpoint and automatic token handling
- add client refresh logic and update docs

## Testing
- `python manage.py test` (fails: can only concatenate str (not "NoneType") to str)
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895888ab970832ebcc479ffd0a63f8b