### PR TITLE
Encode document ID for navigation

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/documents/components/DocumentList.tsx
+++ b/ADPfrontendfor-jsonly-main/src/documents/components/DocumentList.tsx
@@ -40,7 +40,7 @@ const DocumentList = ({ documents }: Props) => {
 
   const viewDocument = (doc: Doc) => {
     dispatch(setDocumentData({ documentId: doc.id, documentData: doc }));
-    navigate(`/document/${doc.id}`);
+    navigate(`/document/${encodeURIComponent(doc.id)}`);
   };
 
   return (

--- a/ADPfrontendfor-jsonly-main/src/documents/pages/DocumentViewer.tsx
+++ b/ADPfrontendfor-jsonly-main/src/documents/pages/DocumentViewer.tsx
@@ -3,7 +3,7 @@ import { FileText, Image, AlertCircle, Loader2, ChevronDown } from 'lucide-react
 import Navbar from '@/shared/components/Navbar';
 import * as XLSX from 'xlsx';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { FiArrowLeft } from "react-icons/fi";
 import { toast } from 'sonner';
 import { apiService } from '@/services/apiService';
@@ -68,6 +68,7 @@ const DocumentViewer: React.FC = () => {
   const [leftPanelWidth, setLeftPanelWidth] = useState(50); // percent
   const isDragging = useRef(false);
   const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
   const reduxDocumentId = useSelector(
     (state: RootState) => state.document.documentId
   );
@@ -107,11 +108,8 @@ const DocumentViewer: React.FC = () => {
       return;
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const urlId = urlParams.get('id') || window.location.pathname.split('/').pop();
-
-    if (urlId) {
-      setDocumentId(urlId);
+    if (id) {
+      setDocumentId(decodeURIComponent(id));
       return;
     }
 
@@ -128,7 +126,7 @@ const DocumentViewer: React.FC = () => {
         handleError(e as { status?: number; message?: string }, 'Error parsing localStorage data');
       }
     }
-  }, [reduxDocumentId, handleError]);
+  }, [reduxDocumentId, id, handleError]);
 
   useEffect(() => {
     if (!documentId) {


### PR DESCRIPTION
## Summary
- URL-encode document IDs before navigating to viewer
- Decode document IDs using `useParams` within `DocumentViewer`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895986f9d20832ea0a5e4c54430e747