### PR TITLE
refactor: use router params for document id

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/documents/pages/DocumentViewer.tsx
+++ b/ADPfrontendfor-jsonly-main/src/documents/pages/DocumentViewer.tsx
@@ -68,13 +68,14 @@ const DocumentViewer: React.FC = () => {
   const [leftPanelWidth, setLeftPanelWidth] = useState(50); // percent
   const isDragging = useRef(false);
   const navigate = useNavigate();
-  const { id } = useParams<{ id: string }>();
-  const reduxDocumentId = useSelector(
-    (state: RootState) => state.document.documentId
-  );
+  const { id } = useParams();
   const userType = useSelector((state: RootState) => state.auth.userType);
   const [processingFull, setProcessingFull] = useState(false);
   const { handleError } = useErrorHandler();
+
+  useEffect(() => {
+    setDocumentId(id ?? null);
+  }, [id]);
 
   const fetchDocumentData = useCallback(async (id: string): Promise<void> => {
     try {
@@ -101,32 +102,6 @@ const DocumentViewer: React.FC = () => {
       setProcessingFull(false);
     }
   };
-
-  useEffect(() => {
-    if (reduxDocumentId) {
-      setDocumentId(reduxDocumentId);
-      return;
-    }
-
-    if (id) {
-      setDocumentId(decodeURIComponent(id));
-      return;
-    }
-
-    const localStorageKeys = Object.keys(localStorage);
-    const documentKey = localStorageKeys.find(key => key.startsWith('document_'));
-
-    if (documentKey) {
-      try {
-        const storedData = JSON.parse(localStorage.getItem(documentKey));
-        if (storedData?.document_id) {
-          setDocumentId(String(storedData.document_id));
-        }
-      } catch (e) {
-        handleError(e as { status?: number; message?: string }, 'Error parsing localStorage data');
-      }
-    }
-  }, [reduxDocumentId, id, handleError]);
 
   useEffect(() => {
     if (!documentId) {


### PR DESCRIPTION
## Summary
- simplify DocumentViewer by using `useParams` to derive document id
- remove local storage fallback and URL parsing for document id

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68959986cfd4832ea4a7d6df866f4f43