### PR TITLE
Fix dashboard token totals from listDocuments response

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/dashboard/pages/UserDashboard.tsx
+++ b/ADPfrontendfor-jsonly-main/src/dashboard/pages/UserDashboard.tsx
@@ -33,13 +33,17 @@ const UserDashboard = () => {
   useEffect(() => {
     if (!accessToken) return;
 
-    apiService.listDocuments()
+    apiService
+      .listDocuments()
       .then((data) => {
-        const { count, documents, total_input_tokens, total_output_tokens } = data;
+        const { count, documents, totalInputTokens, totalOutputTokens } = data;
         setCount(count);
-        setTotal_input_tokens(total_input_tokens);
-        setTotal_output_tokens(total_output_tokens);
-        const docsWithStringId = documents.map((doc) => ({ ...doc, id: String(doc.id) }));
+        setTotal_input_tokens(totalInputTokens);
+        setTotal_output_tokens(totalOutputTokens);
+        const docsWithStringId = documents.map((doc) => ({
+          ...doc,
+          id: String(doc.id),
+        }));
         setDocuments(docsWithStringId);
         setFilteredDocuments(docsWithStringId);
       })

--- a/ADPfrontendfor-jsonly-main/src/services/apiService.ts
+++ b/ADPfrontendfor-jsonly-main/src/services/apiService.ts
@@ -9,6 +9,13 @@ export interface LoginResponse {
   message?: string;
 }
 
+export interface DocumentListResponse {
+  count: number;
+  documents: Record<string, unknown>[];
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+
 export const apiService = {
   login: async (username: string, password: string): Promise<LoginResponse> => {
     return apiClient('/login/', {
@@ -49,8 +56,8 @@ export const apiService = {
     );
   },
 
-  listDocuments: async () => {
-    return apiClient('/documents/');
+  listDocuments: async (): Promise<DocumentListResponse> => {
+    return apiClient('/documents/') as Promise<DocumentListResponse>;
   },
 
   filterDocuments: async (userId: string, date: string) => {


### PR DESCRIPTION
## Summary
- Align listDocuments response typing with camelCase token fields
- Use camelCase token totals from API client in UserDashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68959ce8dd80832ea66125a6d4c2359b