### PR TITLE
refactor: remove duplicate token display in DocumentViewer

### DIFF
--- a/ADPfrontendfor-jsonly-main/src/documents/pages/DocumentViewer.tsx
+++ b/ADPfrontendfor-jsonly-main/src/documents/pages/DocumentViewer.tsx
@@ -229,22 +229,14 @@ const DocumentViewer: React.FC = () => {
               Back
             </button>
             <div className="flex items-center space-x-4">
-              {documentData?.inputToken && (
-                <span className="text-sm text-gray-600">
-                  Input Tokens: <strong>{documentData.inputToken}</strong>
-                </span>
-              )}
-              {documentData?.outputToken && (
-                <span className="text-sm text-gray-600">
-                  Output Tokens: <strong>{documentData.outputToken}</strong>
-                </span>
-              )}
               {documentData?.status && (
-                <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                  documentData.status === 'success'
-                    ? 'bg-green-100 text-green-800'
-                    : 'bg-red-100 text-red-800'
-                }`}>
+                <span
+                  className={`px-3 py-1 rounded-full text-xs font-medium ${
+                    documentData.status === 'success'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-red-100 text-red-800'
+                  }`}
+                >
                   {documentData.status}
                 </span>
               )}


### PR DESCRIPTION
## Summary
- remove input/output token counts from DocumentViewer header
- rely on DocumentProcessingInfo component to display token usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `rg -o "Input Tokens" dist | head -n 20`
- `rg -o "Output Tokens" dist | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6895bca915a4832eb456049a83647cb9