### PR TITLE
Restrict direct media access

### DIFF
--- a/experiencecentrejsononly-main/ImageExtraction/urls.py
+++ b/experiencecentrejsononly-main/ImageExtraction/urls.py
@@ -14,18 +14,15 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-
 from django.urls import path, include
-
-from django.conf.urls.static import static
 from django.conf import settings
+
+from apps.image_app.views import ProtectedDocumentView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("IDA/",include("apps.image_app.urls")),
     path('', include('apps.authentication.urls')),
+    path(f"{settings.MEDIA_URL.lstrip('/')}<path:file_path>",
+         ProtectedDocumentView.as_view(), name="protected-media"),
 ]
-
-
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/experiencecentrejsononly-main/apps/image_app/tests/test_document_access.py
+++ b/experiencecentrejsononly-main/apps/image_app/tests/test_document_access.py
@@ -72,3 +72,8 @@ class DocumentAccessTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Invalid user ID", response.data.get("error", ""))
+
+    def test_unauthorized_user_cannot_access_file_path(self):
+        self.client.force_authenticate(user=self.default_user)
+        response = self.client.get(self.document.file.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Summary
- Gate media file serving behind permission checks
- Add protected media route
- Cover unauthorized file access with tests

## Testing
- `python manage.py test --settings=ImageExtraction.settings_test`


------
https://chatgpt.com/codex/tasks/task_e_6895f291df38832ea3afdcf078e31084